### PR TITLE
New exception because OAuthCommunicationException is not Serializable

### DIFF
--- a/library/src/main/java/com/liferay/mobile/android/oauth/task/AccessTokenAsyncTask.java
+++ b/library/src/main/java/com/liferay/mobile/android/oauth/task/AccessTokenAsyncTask.java
@@ -56,7 +56,7 @@ public class AccessTokenAsyncTask extends AsyncTask<Object, Void, Void> {
 
 	@Override
 	protected void onCancelled() {
-		BusUtil.post(_exception);
+		BusUtil.post(new Exception(_exception.getMessage()));
 	}
 
 	@Override

--- a/library/src/main/java/com/liferay/mobile/android/oauth/task/RequestTokenAsyncTask.java
+++ b/library/src/main/java/com/liferay/mobile/android/oauth/task/RequestTokenAsyncTask.java
@@ -23,6 +23,7 @@ import com.liferay.mobile.android.oauth.bus.BusUtil;
 
 import oauth.signpost.OAuthConsumer;
 import oauth.signpost.OAuthProvider;
+import oauth.signpost.exception.OAuthCommunicationException;
 
 /**
  * @author Bruno Farache
@@ -55,7 +56,7 @@ public class RequestTokenAsyncTask extends AsyncTask<Object, Void, String> {
 
 	@Override
 	protected void onCancelled() {
-		BusUtil.post(_exception);
+		BusUtil.post(new Exception(_exception.getMessage()));
 	}
 
 	@Override


### PR DESCRIPTION
RequestTokenAsyncTask fails if there is no possible connection to a server (for example, device without wifi/3G), instead of throwing a timeout or a status code.

When it fails the exception thrown (OAuthCommunicationException) is not serializable (because HttpHost) and it fails when posting that exception through Otto (Parcelable encountered IOException writing serializable object).

Not the best code (didn't wanted to do an instanceOf of a specific exception). Feel free to fix it as you wish.
